### PR TITLE
Hability to overwrite embed code on the backends

### DIFF
--- a/embed_video/backends.py
+++ b/embed_video/backends.py
@@ -9,8 +9,7 @@ except:
 
 
 from .utils import import_by_path
-from .settings import EMBED_VIDEO_BACKENDS, EMBED_VIDEO_CACHE, \
-                      EMBED_VIDEO_CACHE_TIMEOUT
+from .settings import EMBED_VIDEO_BACKENDS, EMBED_VIDEO_CACHE
 
 cache = None
 if EMBED_VIDEO_CACHE:

--- a/embed_video/templatetags/embed_video_tags.py
+++ b/embed_video/templatetags/embed_video_tags.py
@@ -1,7 +1,7 @@
 from django.template import Library, Node, TemplateSyntaxError
-from django.utils.safestring import mark_safe, SafeText
+from django.utils.safestring import mark_safe
 
-from ..backends import detect_backend, SoundCloudBackend, VideoBackend
+from ..backends import detect_backend, VideoBackend
 
 register = Library()
 


### PR DESCRIPTION
Embed code should be based on the backend since not every video provider uses an iframe code to embed it's videos.

This also removes **SoundCloudBackend** hack to change the embed code's height.
