### PR TITLE
Added `video_embed` tag that accepts kwargs

### DIFF
--- a/docs/api/embed_video.settings.rst
+++ b/docs/api/embed_video.settings.rst
@@ -25,3 +25,27 @@ EMBED_VIDEO_TIMEOUT
 Sets timeout for ``GET`` requests to remote servers.
 
 Default: ``10``
+
+
+.. setting:: EMBED_VIDEO_{BACKEND}_QUERY
+
+EMBED_VIDEO_{BACKEND}_QUERY
+---------------------------
+
+Set default query dictionary for including in the embedded URL.  This is
+backend-specific.  Substitute the actual name of the backend for {BACKEND}
+(i.e. to set the default query for the YouTube backend, the setting name would
+be ``EMBED_VIDEO_YOUTUBE_QUERY`` and for SoundCloud the name would be
+``EMBED_VIDEO_SOUNDCLOUD_QUERY``).  
+
+As an example, if you set the following::
+
+    EMBED_VIDEO_YOUTUBE_QUERY = {
+        'wmode': 'opaque',
+        'rel': '0'
+    }
+
+All URLs for YouTube will include the query string ``?wmode=opaque&rel=0``.
+
+The default value for EMBED_VIDEO_YOUTUBE_QUERY is ``{'wmode': 'opaque'}``.
+None of the other backends have default values set.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -48,6 +48,34 @@ Default sizes are ``tiny`` (420x315), ``small`` (480x360), ``medium`` (640x480),
       {% video my_video '100% x 50%' %}
 
 
+Some backends (e.g. YouTube) allow configuration of the embedding via passing
+query parameters.  To specify the parameters:
+
+::
+
+    {% video item.video 'small' rel=0 %}
+
+    {% video item.video 'small' start=2 stop=5 repeat=1 %}
+
+    {% video item.video rel=0 as my_video %}
+        URL: {{ my_video.url }}
+        Thumbnail: {{ my_video.thumbnail }}
+        Backend: {{ my_video.backend }}
+        {% video my_video 'small' %}
+    {% endvideo %}
+
+Parameters may also be template variables:
+
+::
+
+    {% video item.video 'small' start=item.start stop=item.stop repeat=item.repeat %}
+
+
+.. tip:: 
+
+  You can provide default values for the query string that's included in the
+  embedded URL by updating your Django settings file.
+
 
 .. tip::
 


### PR DESCRIPTION
Some video backends support optional arguments embedded in the URL query
string that adjust how the video is displayed (e.g. Youtube supports
rel=0 which means don't show related videos).  Created a tag that
takes keyword arguments and embeds them into the URL query string.

This tag also supports appending to existing queries hard-coded in the
video backend URL (e.g. Youtube's backend has a hard-coded query of
wmod=opaque).
