### PR TITLE
Fix string formating

### DIFF
--- a/embed_video/fields.py
+++ b/embed_video/fields.py
@@ -47,6 +47,6 @@ class EmbedVideoFormField(forms.URLField):
         except UnknownBackendException:
             raise forms.ValidationError(_(u'URL could not be recognized.'))
         except UnknownIdException:
-            raise forms.ValidationError(_(u'ID of this video could not be \
-                                            recognized.'))
+            raise forms.ValidationError(_(u'ID of this video could not be '
+                                          u'recognized.'))
         return url


### PR DESCRIPTION
There is a lot of spaces in this error message.

By the way, this is never raised in normal condition. The `detect_backend` doesn't try to `get_code()` at all.
