### PR TITLE
Change requests.get kwarg from data to params when calling SoundCloud AP...

### DIFF
--- a/embed_video/backends.py
+++ b/embed_video/backends.py
@@ -290,7 +290,7 @@ class SoundCloudBackend(VideoBackend):
             'format': 'json',
             'url': self._url,
         }
-        r = requests.get(self.base_url, data=params,
+        r = requests.get(self.base_url, params=params,
                          timeout=EMBED_VIDEO_TIMEOUT)
 
         if r.status_code != 200:


### PR DESCRIPTION
This was failing for me with an error 400 error, and the requests docs (http://docs.python-requests.org/en/latest/user/quickstart/#passing-parameters-in-urls) say to use a kwarg called params rather than data. I've changed this and it now works. Not sure if this is something which has changed in the requests lib.
