### PR TITLE
Adding support for Vimeo channels (eg. Staff picks)

### DIFF
--- a/embed_video/backends.py
+++ b/embed_video/backends.py
@@ -291,7 +291,7 @@ class VimeoBackend(VideoBackend):
     re_detect = re.compile(
         r'^((http(s)?:)?//)?(www\.)?(player\.)?vimeo\.com/.*', re.I
     )
-    re_code = re.compile(r'''vimeo\.com/(video/)?(?P<code>[0-9]+)''', re.I)
+    re_code = re.compile(r'''vimeo\.com/(video/)?(channels/(.*/)?)?(?P<code>[0-9]+)''', re.I)
     pattern_url = '{protocol}://player.vimeo.com/video/{code}'
     pattern_info = '{protocol}://vimeo.com/api/v2/video/{code}.json'
 

--- a/embed_video/tests/backends/tests_vimeo.py
+++ b/embed_video/tests/backends/tests_vimeo.py
@@ -14,6 +14,8 @@ class VimeoBackendTestCase(BackendTestMixin, TestCase):
         ('https://www.vimeo.com/72304002', '72304002'),
         ('http://player.vimeo.com/video/72304002', '72304002'),
         ('https://player.vimeo.com/video/72304002', '72304002'),
+        ('http://www.vimeo.com/channels/staffpick/72304002', '72304002'),
+        ('https://www.vimeo.com/channels/staffpick/72304002', '72304002'),
     )
 
     instance = VimeoBackend


### PR DESCRIPTION
I noticed the featured videos on Vimeo's home page tend to be "staff picks", which have a different url structure, probably to give some extra context to the view that renders the video.  These videos can also be accessed through the more traditional url path, but because the staffpicks links are on the home page, I am concerned my users will be trying to paste in what they think are valid video urls, only to have them failing.  

This adjusted regex is a bit aggressive, allowing for other channels to host videos (currently I don't believe any do, but they might if the staff picks are able to), so that could be tweaked.
