### PR TITLE
Adds Wistia video support

### DIFF
--- a/embed_video/backends.py
+++ b/embed_video/backends.py
@@ -373,6 +373,7 @@ class WistiaBackend(VideoBackend):
     Backend for Wistia URLs.
     """
     domain = None
+    is_secure = True
 
     re_detect = re.compile(r'https://(?P<domain>[a-z]+).wistia.com/medias/*', re.I)
     re_code = re.compile(r'''wistia\.com/(medias/(.*/)?|deliveries/)(?P<code>[a-z0-9;:@?&%=+/\$_.-]+)''', re.I)

--- a/embed_video/backends.py
+++ b/embed_video/backends.py
@@ -368,6 +368,50 @@ class VimeoBackend(VideoBackend):
         return self.info.get('thumbnail_large')
 
 
+class WistiaBackend(VideoBackend):
+    """
+    Backend for Wistia URLs.
+    """
+    domain = None
+
+    re_detect = re.compile(r'https://(?P<domain>[a-z]+).wistia.com/medias/*', re.I)
+    re_code = re.compile(r'''wistia\.com/(medias/(.*/)?|deliveries/)(?P<code>[a-z0-9;:@?&%=+/\$_.-]+)''', re.I)
+
+    pattern_url = '{protocol}://fast.wistia.net/embed/iframe/{code}'
+    pattern_info = '{protocol}://fast.wistia.net/oembed?url={protocol}%3A%2F%2F{domain}.wistia.com%2Fmedias%2F{code}&embedType=async'
+
+    @cached_property
+    def width(self):
+        """
+        :rtype: str
+        """
+        return self.info.get('width')
+
+    @cached_property
+    def height(self):
+        """
+        :rtype: str
+        """
+        return self.info.get('height')
+
+    def get_info(self):
+        try:
+            response = requests.get(
+                self.pattern_info.format(domain=self.domain, code=self.code, protocol=self.protocol), timeout=EMBED_VIDEO_TIMEOUT
+            )
+            return json.loads(response.text)
+        except ValueError:
+            raise VideoDoesntExistException()
+
+    def get_thumbnail_url(self):
+        """
+        Returns thumbnail URL folded from :py:data:`pattern_thumbnail_url` and
+        parsed code.
+        :rtype: str
+        """
+        return self.info.get('thumbnail_url')
+
+
 class SoundCloudBackend(VideoBackend):
     """
     Backend for SoundCloud URLs.

--- a/embed_video/settings.py
+++ b/embed_video/settings.py
@@ -4,6 +4,7 @@ from django.conf import settings
 EMBED_VIDEO_BACKENDS = getattr(settings, 'EMBED_VIDEO_BACKENDS', (
     'embed_video.backends.YoutubeBackend',
     'embed_video.backends.VimeoBackend',
+    'embed_video.backends.WistiaBackend',
     'embed_video.backends.SoundCloudBackend',
 ))
 """ :type: tuple[str] """

--- a/embed_video/tests/backends/tests_wistia.py
+++ b/embed_video/tests/backends/tests_wistia.py
@@ -17,7 +17,7 @@ class WistiaBackendTestCase(BackendTestMixin, TestCase):
 
     def test_wistia_get_info_exception(self):
         with self.assertRaises(VideoDoesntExistException):
-            backend = WistiaBackend('http://support.wistia.com/123')
+            backend = WistiaBackend('https://support.wistia.com/123')
             backend.get_info()
 
     def test_get_thumbnail_url(self):

--- a/embed_video/tests/backends/tests_wistia.py
+++ b/embed_video/tests/backends/tests_wistia.py
@@ -1,0 +1,31 @@
+import requests
+from mock import patch
+from unittest import TestCase
+
+from . import BackendTestMixin
+from embed_video.backends import WistiaBackend, VideoDoesntExistException
+
+
+class WistiaBackendTestCase(BackendTestMixin, TestCase):
+
+    urls = (
+        ('https://support.wistia.com/medias/26sk4lmiix', '26sk4lmiix'),  # This comes from the wistia docs
+        ('https://home.wistia.com/medias/342jss6yh5', '342jss6yh5'),
+    )
+
+    instance = WistiaBackend
+
+    def test_wistia_get_info_exception(self):
+        with self.assertRaises(VideoDoesntExistException):
+            backend = WistiaBackend('http://support.wistia.com/123')
+            backend.get_info()
+
+    def test_get_thumbnail_url(self):
+        backend = WistiaBackend('https://home.wistia.com/medias/342jss6yh5')
+        self.assertEqual(backend.get_thumbnail_url(),
+                         'https://embed-ssl.wistia.com/deliveries/7fc8174a908ad1d349196405671e0fbdaa1e84eb.jpg?image_crop_resized=960x540')
+
+    @patch('embed_video.backends.EMBED_VIDEO_TIMEOUT', 0.000001)
+    def test_timeout_in_get_info(self):
+        backend = WistiaBackend('http://support.wistia.com/72304002')
+        self.assertRaises(requests.Timeout, backend.get_info)

--- a/embed_video/tests/django_settings.py
+++ b/embed_video/tests/django_settings.py
@@ -19,6 +19,7 @@ EMBED_VIDEO_BACKENDS = (
     'embed_video.backends.YoutubeBackend',
     'embed_video.backends.VimeoBackend',
     'embed_video.backends.SoundCloudBackend',
+    'embed_video.backends.WistiaBackend',
     'embed_video.tests.backends.tests_custom_backend.CustomBackend',
 )
 


### PR DESCRIPTION
# What Is this?

https://wistia.com/ provides a video service similar to that of youtube, or vimeo. The added benefit being analytics, and a full set of features to customize the look of the video, and how it behaves.
# Why add this?

Wistia is becoming a popular go-to for businesses that want to have video's embedded on their site. This Link: https://wistia.com/blog/wistia-vs-youtube provides a pretty good run-down of why businesses would choose wistia over youtube.
# How to test?

Simply run the nose tests supplied, and to test usability simply use the example project provided, and upload one of the available wistia video urls in place of a vimeo or youtube video. 
Public wistia videos are difficult to find, but I have provided two links in the test_wistia_video_embed file. 
