### PR TITLE
Use secure connection to query soundcloud endpoint

### DIFF
--- a/embed_video/backends.py
+++ b/embed_video/backends.py
@@ -372,7 +372,7 @@ class SoundCloudBackend(VideoBackend):
     """
     Backend for SoundCloud URLs.
     """
-    base_url = 'http://soundcloud.com/oembed'
+    base_url = '{protocol}://soundcloud.com/oembed'
 
     re_detect = re.compile(r'^(http(s)?://(www\.)?)?soundcloud\.com/.*', re.I)
     re_code = re.compile(r'src=".*%2F(?P<code>\d+)&show_artwork.*"', re.I)
@@ -397,7 +397,8 @@ class SoundCloudBackend(VideoBackend):
             'format': 'json',
             'url': self._url,
         }
-        r = requests.get(self.base_url, params=params,
+        r = requests.get(self.base_url.format(protocol=self.protocol),
+                         params=params,
                          timeout=EMBED_VIDEO_TIMEOUT)
 
         if r.status_code != 200:

--- a/embed_video/tests/templatetags/tests_embed_video_tags.py
+++ b/embed_video/tests/templatetags/tests_embed_video_tags.py
@@ -160,7 +160,7 @@ class EmbedTestCase(TestCase):
 
         self.assertRenderedTemplate(template, '')
         logs.check(
-            ('requests.packages.urllib3.connectionpool', 'INFO', 'Starting new HTTP connection (1): vimeo.com'),
+            ('requests.packages.urllib3.connectionpool', 'DEBUG', 'Starting new HTTP connection (1): vimeo.com'),
             ('embed_video.templatetags.embed_video_tags', 'ERROR', 'Timeout reached during rendering embed video (`http://vimeo.com/72304002`)')
         )
 
@@ -281,4 +281,3 @@ class EmbedVideoNodeTestCase(TestCase):
         context = {'request': InsecureRequest()}
         backend = VideoNode.get_backend('http://www.youtube.com/watch?v=jsrRJyHBvzw', context)
         self.assertFalse(backend.is_secure)
-


### PR DESCRIPTION
Use https to query the Soundcloud oembed endpoint if is_secure is set on the Soundcloud backend.