### PR TITLE
Update requirements for installation of the example project

### DIFF
--- a/embed_video/tests/templatetags/tests_embed_video_tags.py
+++ b/embed_video/tests/templatetags/tests_embed_video_tags.py
@@ -160,7 +160,7 @@ class EmbedTestCase(TestCase):
 
         self.assertRenderedTemplate(template, '')
         logs.check(
-            ('requests.packages.urllib3.connectionpool', 'INFO', 'Starting new HTTP connection (1): vimeo.com'),
+            ('requests.packages.urllib3.connectionpool', 'DEBUG', 'Starting new HTTP connection (1): vimeo.com'),
             ('embed_video.templatetags.embed_video_tags', 'ERROR', 'Timeout reached during rendering embed video (`http://vimeo.com/72304002`)')
         )
 

--- a/example_project/README.rst
+++ b/example_project/README.rst
@@ -1,10 +1,9 @@
 Running example project
 ***********************
 
-#. Install Django and PyYAML::
+#. Install requirements::
 
-     pip install Django
-     pip install pyyaml
+     pip install -r requirements.txt
 
 #. Create database::
 

--- a/example_project/requirements.txt
+++ b/example_project/requirements.txt
@@ -1,1 +1,3 @@
 Django>=1.5
+pyyaml
+requests


### PR DESCRIPTION
Example project doesn't work until `requests` are installed (in a fresh environment).