### PR TITLE
(maybe) Fix pypi docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
 Release 1.2.0 (October 04, 2018)
-----------------------------
+--------------------------------
 
 - hotfix docs directive
   (`#94 <https://github.com/jazzband/django-embed-video/pull/94>`_)
@@ -23,13 +23,13 @@ Release 1.2.0 (October 04, 2018)
 
 
 Release 1.1.2 (April 27, 2017)
-----------------------------
+------------------------------
 
 - fix pypi
 
 
 Release 1.1.1 (March 24, 2017)
-----------------------------
+------------------------------
 
 - updates for Django 1.10 and 1.11
   (`#73 <https://github.com/jazzband/django-embed-video/pull/73>`_)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     keywords=['youtube', 'vimeo', 'video', 'soundcloud'],
     install_requires=['requests >= 1.2.3', 'Django >= 1.5'],
-    setup_requires=['nose'],
+    setup_requires=['nose', 'readme'],
     tests_require=['Django', 'requests >= 2.19', 'mock', 'testfixtures', 'south', 'coverage'],
     test_suite='nose.collector',
 )

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     url='https://github.com/jazzband/django-embed-video',
     description=embed_video.__doc__.strip(),
     long_description='\n\n'.join([README, CHANGES]),
+    long_description_content_type='text/x-rst',
     classifiers=[
         'Framework :: Django',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
As @CedricCarrard noted, something has gone wrong with [the v1.2.0 docs on PyPi](https://pypi.org/project/django-embed-video/1.2.0/#description).

There were some errors that were revealed by running `python setup.py check -r` which I fixed, but they were also present in the previous version.  Maybe whatever they use for rendering got more picky. 

Also explicitly adding a content type for the long_description so it isn't up to PyPi to autodetect it.