### PR TITLE
Fix a Python 3.6+ DeprecationWarning

### DIFF
--- a/embed_video/templatetags/embed_video_tags.py
+++ b/embed_video/templatetags/embed_video_tags.py
@@ -55,7 +55,7 @@ class VideoNode(Node):
                 '[size] [key1=val1 key2=val2 ...] [as var] %}``'
     default_size = 'small'
 
-    re_size = re.compile('[\'"]?(?P<width>\d+%?) *x *(?P<height>\d+%?)[\'"]?')
+    re_size = re.compile(r'[\'"]?(?P<width>\d+%?) *x *(?P<height>\d+%?)[\'"]?')
     re_option = re.compile(r'^(?P<key>[\w]+)=(?P<value>.+)$')
 
     def __init__(self, parser, token):


### PR DESCRIPTION
Explicitly mark a regular expression string as raw to avoid `DeprecationWarning: invalid escape sequence` warning in Python 3.6+