### PR TITLE
added VideoDoesntExistException to field validation

### DIFF
--- a/embed_video/fields.py
+++ b/embed_video/fields.py
@@ -2,7 +2,8 @@ from django.db import models
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
-from .backends import detect_backend, UnknownIdException, UnknownBackendException
+from .backends import (detect_backend, UnknownIdException,
+    UnknownBackendException, VideoDoesntExistException)
 
 __all__ = ("EmbedVideoField", "EmbedVideoFormField")
 
@@ -41,4 +42,6 @@ class EmbedVideoFormField(forms.URLField):
             raise forms.ValidationError(
                 _("ID of this video could not be " "recognized.")
             )
+        except VideoDoesntExistException:
+            raise forms.ValidationError(_("This media not found on site."))
         return url


### PR DESCRIPTION
If you try link like "https://soundcloud.com/bla_bla/bla" without this
changes, you see exception in Django admin areа instead validation
error.