### PR TITLE
Update CHANGES.rst for release 1.4.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,16 @@ Changes
 =======
 
 
+Release 1.4.0 (December ??, 2020)
+------------------------------
+
+- Handle Vimeo admin "manage" URLs
+- Drop unsupported Django versions prior to 2.2.
+- Add support for Python up to 3.9.
+- Add support for Django up to 3.1.
+- Improve code formatting.
+
+
 Release 1.3.3 (June 10, 2020)
 ------------------------------
 


### PR DESCRIPTION
Figure it's time to prepare a release, and so updating the changelog.  I think this covers all the things that have [changed since 1.3.3](https://github.com/jazzband/django-embed-video/compare/1.3.3...master).

_Normally I'd think this should be a breaking 2.0 change since we're dropping support for a few Django versions but it appears that hasn't been the pattern in this project so just going with 1.4.0._