### PR TITLE
Lazy loading for videos

### DIFF
--- a/embed_video/templates/embed_video/embed_code.html
+++ b/embed_video/templates/embed_video/embed_code.html
@@ -1,1 +1,1 @@
-<iframe width="{{ width }}" height="{{ height }}" src="{{ backend.url }}" frameborder="0" allowfullscreen></iframe>
+<iframe width="{{ width }}" height="{{ height }}" src="{{ backend.url }}" loading="lazy" frameborder="0" allowfullscreen></iframe>

--- a/embed_video/tests/templatetags/tests_embed_video_tags.py
+++ b/embed_video/tests/templatetags/tests_embed_video_tags.py
@@ -59,7 +59,7 @@ class EmbedTestCase(TestCase):
             template,
             '<iframe width="960" height="720" '
             'src="https://www.youtube.com/embed/jsrRJyHBvzw?wmode=opaque" '
-            'frameborder="0" allowfullscreen></iframe>',
+            'loading="lazy" frameborder="0" allowfullscreen></iframe>',
         )
 
     def test_embed_invalid_url(self):
@@ -95,7 +95,7 @@ class EmbedTestCase(TestCase):
             template,
             '<iframe width="960" height="720" '
             'src="https://www.youtube.com/embed/jsrRJyHBvzw?wmode=opaque" '
-            'frameborder="0" allowfullscreen></iframe>',
+            'loading="lazy" frameborder="0" allowfullscreen></iframe>',
         )
 
     def test_direct_embed_tag_with_default_size(self):
@@ -107,7 +107,7 @@ class EmbedTestCase(TestCase):
             template,
             '<iframe width="480" height="360" '
             'src="https://www.youtube.com/embed/jsrRJyHBvzw?wmode=opaque" '
-            'frameborder="0" allowfullscreen></iframe>',
+            'loading="lazy" frameborder="0" allowfullscreen></iframe>',
         )
 
     def test_direct_embed_invalid_url(self):
@@ -128,7 +128,7 @@ class EmbedTestCase(TestCase):
             template,
             '<iframe width="800" height="800" '
             'src="https://www.youtube.com/embed/jsrRJyHBvzw?wmode=opaque" '
-            'frameborder="0" allowfullscreen></iframe>',
+            'loading="lazy" frameborder="0" allowfullscreen></iframe>',
         )
 
     def test_wrong_size(self):
@@ -207,7 +207,7 @@ class EmbedTestCase(TestCase):
             template,
             '<iframe width="80%" height="30%" '
             'src="https://player.vimeo.com/video/72304002" '
-            'frameborder="0" allowfullscreen></iframe>',
+            'loading="lazy" frameborder="0" allowfullscreen></iframe>',
         )
 
     def test_allow_spaces_in_size(self):
@@ -219,7 +219,7 @@ class EmbedTestCase(TestCase):
             template,
             '<iframe width="80%" height="300" '
             'src="https://player.vimeo.com/video/72304002" '
-            'frameborder="0" allowfullscreen></iframe>',
+            'loading="lazy" frameborder="0" allowfullscreen></iframe>',
         )
 
     def test_embed_with_query(self):
@@ -259,7 +259,7 @@ class EmbedTestCase(TestCase):
             output_without_url,
             '<iframe width="480" height="360" '
             'src="URL" '
-            'frameborder="0" allowfullscreen></iframe>',
+            'loading="lazy" frameborder="0" allowfullscreen></iframe>',
         )
 
     def test_set_options(self):
@@ -271,7 +271,7 @@ class EmbedTestCase(TestCase):
             template,
             '<iframe width="300" height="200" '
             'src="https://www.youtube.com/embed/jsrRJyHBvzw?rel=1" '
-            'frameborder="0" allowfullscreen></iframe>',
+            'loading="lazy" frameborder="0" allowfullscreen></iframe>',
         )
 
     def test_size_as_variable(self):
@@ -285,7 +285,7 @@ class EmbedTestCase(TestCase):
             template,
             '<iframe width="500" height="200" '
             'src="https://www.youtube.com/embed/jsrRJyHBvzw?wmode=opaque" '
-            'frameborder="0" allowfullscreen></iframe>',
+            'loading="lazy" frameborder="0" allowfullscreen></iframe>',
         )
 
 


### PR DESCRIPTION
See

- Fixes #133
- https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading
- https://web.dev/browser-level-image-lazy-loading/

Browsers that do not support the loading attribute simply ignore it without side-effects.