### PR TITLE
Adding RST formatted link to example-project.rst

### DIFF
--- a/docs/example-project.rst
+++ b/docs/example-project.rst
@@ -2,6 +2,6 @@ Example project
 ===============
 
 For easy start with using django-embed-video, you can take a look at example
-project. It is located in example_project directory in root of repository.
+project. It is located in [example_project directory](https://github.com/jazzband/django-embed-video/tree/master/example_project) in root of repository.
 
 .. include:: ../example_project/README.rst

--- a/docs/example-project.rst
+++ b/docs/example-project.rst
@@ -2,6 +2,6 @@ Example project
 ===============
 
 For easy start with using django-embed-video, you can take a look at example
-project. It is located in [example_project directory](https://github.com/jazzband/django-embed-video/tree/master/example_project) in root of repository.
+project. It is located in `example_project directory <https://github.com/jazzband/django-embed-video/tree/master/example_project>`_ in root of repository.
 
 .. include:: ../example_project/README.rst


### PR DESCRIPTION
RST should be fixed --  i've never fixed a patch like this so let me know if this isn't the way.