### PR TITLE
Add setting EMBED_VIDEO_YOUTUBE_CHECK_THUMBNAIL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,9 @@
 Changes
 =======
 
+- Add ``EMBED_VIDEO_YOUTUBE_CHECK_THUMBNAIL`` to settings.
+
+
 Unreleased
 ----------
 

--- a/docs/api/embed_video.settings.rst
+++ b/docs/api/embed_video.settings.rst
@@ -39,3 +39,15 @@ Sets default :py:attr:`~embed_video.backends.VideoBackend.query` appended
 to YouTube url. Can be string or :py:class:`~django.http.QueryDict` instance.
 
 Default: ``"wmode=opaque"``
+
+
+.. setting:: EMBED_VIDEO_YOUTUBE_CHECK_THUMBNAIL
+
+
+EMBED_VIDEO_YOUTUBE_CHECK_THUMBNAIL
+-----------------------------------
+
+Sets whether to check thumbnail for YouTube. If ``False``, it uses ``high``
+resulution as it's guaranteed to exist.
+
+Default: ``True``

--- a/embed_video/backends.py
+++ b/embed_video/backends.py
@@ -12,6 +12,7 @@ from django.utils.safestring import mark_safe
 from embed_video.settings import (
     EMBED_VIDEO_BACKENDS,
     EMBED_VIDEO_TIMEOUT,
+    EMBED_VIDEO_YOUTUBE_CHECK_THUMBNAIL,
     EMBED_VIDEO_YOUTUBE_DEFAULT_QUERY,
 )
 
@@ -341,6 +342,10 @@ class YoutubeBackend(VideoBackend):
 
         :rtype: str
         """
+        if not EMBED_VIDEO_YOUTUBE_CHECK_THUMBNAIL:
+            return self.pattern_thumbnail_url.format(
+                code=self.code, protocol=self.protocol, resolution="hqdefault.jpg"
+            )
         for resolution in self.resolutions:
             temp_thumbnail_url = self.pattern_thumbnail_url.format(
                 code=self.code, protocol=self.protocol, resolution=resolution

--- a/embed_video/settings.py
+++ b/embed_video/settings.py
@@ -18,3 +18,8 @@ EMBED_VIDEO_YOUTUBE_DEFAULT_QUERY = getattr(
     settings, "EMBED_VIDEO_YOUTUBE_DEFAULT_QUERY", "wmode=opaque"
 )
 """ :type: django.db.models.QuerySet | str """
+
+EMBED_VIDEO_YOUTUBE_CHECK_THUMBNAIL = getattr(
+    settings, "EMBED_VIDEO_YOUTUBE_CHECK_THUMBNAIL", True
+)
+""" :type: bool """

--- a/embed_video/tests/backends/tests_youtube.py
+++ b/embed_video/tests/backends/tests_youtube.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from embed_video.backends import UnknownIdException, YoutubeBackend
 from embed_video.tests.backends import BackendTestMixin
@@ -60,3 +61,8 @@ class YoutubeBackendTestCase(BackendTestMixin, TestCase):
         self.assertIn(
             "img.youtube.com/vi/1Zo0-sWD7xE/maxresdefault.jpg", backend.thumbnail
         )
+
+    @patch("embed_video.backends.EMBED_VIDEO_YOUTUBE_CHECK_THUMBNAIL", False)
+    def test_youtube_not_check_thumbnail(self):
+        backend = self.instance("https://www.youtube.com/watch?v=not-exist")
+        self.assertIn("img.youtube.com/vi/not-exist/hqdefault.jpg", backend.thumbnail)


### PR DESCRIPTION
Closes #176 

Changes and docs are updated.

Unit test is added.

I tested performance locally. With it set to `False`, a page with 2 youtube videos responses within 10ms, while by default it's more than 1s.

Ref: https://developers.google.com/youtube/v3/docs/thumbnails