### PR TITLE
Add options to migrations

### DIFF
--- a/example_project/posts/migrations/0001_initial.py
+++ b/example_project/posts/migrations/0001_initial.py
@@ -19,5 +19,6 @@ class Migration(migrations.Migration):
                 ('title', models.CharField(max_length=50)),
                 ('video', embed_video.fields.EmbedVideoField(help_text='This is a help text', verbose_name='My video')),
             ],
+            options={'ordering': ['pk']},
         ),
     ]


### PR DESCRIPTION
This removes the unnecessary `makemigrations` step described in #190 