### PR TITLE
Use importlib.metadata instead of deprecated pkg_resources

### DIFF
--- a/embed_video/__init__.py
+++ b/embed_video/__init__.py
@@ -1,3 +1,8 @@
-from pkg_resources import get_distribution
+import sys
 
-__version__ = get_distribution("django-embed-video").version
+if sys.version_info >= (3, 8):
+    import importlib.metadata as metadata
+else:
+    import importlib_metadata as metadata
+
+__version__ = metadata.version("django-embed-video")

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,11 @@ setup(
         "Topic :: Internet :: WWW/HTTP",
     ],
     keywords=["youtube", "vimeo", "video", "soundcloud"],
-    install_requires=["requests >= 2.19", "Django >= 3.2"],
+    install_requires=[
+        "requests >= 2.19",
+        "Django >= 3.2",
+        "importlib-metadata; python_version < '3.8'",
+    ],
     setup_requires=["readme", "setuptools_scm"],
     tests_require=["Django", "requests >= 2.19", "coverage"],
 )


### PR DESCRIPTION
I am not sure if this package still supports python<3.8 (no constraints in python_requires)