### PR TITLE
Add Django 5.2 support to CI and packaging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        django-version: ['3.2', '4.1', '4.2', '5.0', '5.1']
+        django-version: ['3.2', '4.1', '4.2', '5.0', '5.1', '5.2']
         include:
           # Tox configuration for QA environment
           - python-version: '3.11'
@@ -29,7 +29,7 @@ jobs:
           # Exclude Django 3.2 for Python 3.11
           - python-version: '3.11'
             django-version: '3.2'
-          # Django 5.0/5.1 don't support < Python 3.10
+          # Django 5.0/5.1/5.2 don't support < Python 3.10
           - python-version: '3.8'
             django-version: '5.0'
           - python-version: '3.9'
@@ -38,6 +38,10 @@ jobs:
             django-version: '5.1'
           - python-version: '3.9'
             django-version: '5.1'
+          - python-version: '3.8'
+            django-version: '5.2'
+          - python-version: '3.9'
+            django-version: '5.2'
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
         "Framework :: Django :: 5.1",
+        "Framework :: Django :: 5.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     py{38,39,310,311}-dj42
     py{310,311,312}-dj50
     py{310,311,312}-dj51
+    py{310,311,312}-dj52
     py{311}-djmain
     py{311}-djqa
 
@@ -26,6 +27,7 @@ DJANGO =
     4.2: dj42
     5.0: dj50
     5.1: dj51
+    5.2: dj52
     main: djmain
     qa: djqa
 
@@ -37,6 +39,7 @@ deps =
     dj42: django>=4.2,<4.3
     dj50: django>=5.0,<5.1
     dj51: django>=5.1,<5.2
+    dj52: django>=5.2,<5.3
     djmain: https://github.com/django/django/archive/main.tar.gz
     coverage
     requests-mock


### PR DESCRIPTION
### What’s new

- Added Django 5.2 to test matrix (CI)
- Included Django 5.2 in `setup.py` classifiers
- Updated `tox.ini` to support Django 5.2

### Purpose

Ensure compatibility with the latest Django release.
