### PR TITLE
test: improve Vimeo thumbnail URL assertion by ignoring query params

### DIFF
--- a/embed_video/tests/backends/tests_vimeo.py
+++ b/embed_video/tests/backends/tests_vimeo.py
@@ -1,6 +1,6 @@
+import urllib.parse
 from unittest import TestCase
 from unittest.mock import patch
-import urllib.parse
 
 import requests
 

--- a/embed_video/tests/backends/tests_vimeo.py
+++ b/embed_video/tests/backends/tests_vimeo.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from unittest.mock import patch
+import urllib.parse
 
 import requests
 
@@ -39,9 +40,17 @@ class VimeoBackendTestCase(TestCase):
 
     def test_get_thumbnail_url(self):
         backend = VimeoBackend("https://vimeo.com/72304002")
+        expected_url = "https://i.vimeocdn.com/video/446150690-9621b882540b53788eaa36ef8e303d4e06fc40af3d27918b7f561bb44ed971dc-d_640"
+        actual_url = backend.get_thumbnail_url()
+        
+        # Parse URLs and compare without query parameters
+        expected_parts = urllib.parse.urlparse(expected_url)
+        actual_parts = urllib.parse.urlparse(actual_url)
+        
+        # Compare scheme, netloc, and path only
         self.assertEqual(
-            backend.get_thumbnail_url(),
-            "https://i.vimeocdn.com/video/446150690-9621b882540b53788eaa36ef8e303d4e06fc40af3d27918b7f561bb44ed971dc-d_640?region=us",
+            (expected_parts.scheme, expected_parts.netloc, expected_parts.path),
+            (actual_parts.scheme, actual_parts.netloc, actual_parts.path)
         )
 
     @patch("embed_video.backends.EMBED_VIDEO_TIMEOUT", 0.000001)

--- a/embed_video/tests/backends/tests_vimeo.py
+++ b/embed_video/tests/backends/tests_vimeo.py
@@ -42,15 +42,15 @@ class VimeoBackendTestCase(TestCase):
         backend = VimeoBackend("https://vimeo.com/72304002")
         expected_url = "https://i.vimeocdn.com/video/446150690-9621b882540b53788eaa36ef8e303d4e06fc40af3d27918b7f561bb44ed971dc-d_640"
         actual_url = backend.get_thumbnail_url()
-        
+
         # Parse URLs and compare without query parameters
         expected_parts = urllib.parse.urlparse(expected_url)
         actual_parts = urllib.parse.urlparse(actual_url)
-        
+
         # Compare scheme, netloc, and path only
         self.assertEqual(
             (expected_parts.scheme, expected_parts.netloc, expected_parts.path),
-            (actual_parts.scheme, actual_parts.netloc, actual_parts.path)
+            (actual_parts.scheme, actual_parts.netloc, actual_parts.path),
         )
 
     @patch("embed_video.backends.EMBED_VIDEO_TIMEOUT", 0.000001)


### PR DESCRIPTION
Another change pulled from @mahdirahimi1999's https://github.com/jazzband/django-embed-video/pull/214